### PR TITLE
Added no-standard logging

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -74,13 +74,13 @@ npm run test
 
 By default tests are run using Google Chrome, to run tests using another browser supply the name of that browser along with the `-b` switch. Available options are:
 
-Browser         | Example               | Further info
-----------      | ---------------       | ------------------
-Chrome          | `-b chrome`           |
-Firefox         | `-b firefox`          |
-Electron        | `-b electron`         | Electron support sketchy at the moment
-Chrome Headless | `-b chromeHeadless`   | Only chrome headless support for now
-Custom          | `-b customDriver.js`  |
+Browser         | Example
+----------      | ---------------
+Chrome          | `-b chrome`
+Firefox         | `-b firefox`
+Electron        | `-b electron`        -- Electron support sketchy at the moment
+Chrome Headless | `-b chromeHeadless`  -- Only chrome headless support for now
+Custom          | `-b customDriver.js`
 
 To use your own driver, create a customDriver.js file in the root of your project and provide the filename with the `-b` switch.
 

--- a/README.MD
+++ b/README.MD
@@ -74,13 +74,13 @@ npm run test
 
 By default tests are run using Google Chrome, to run tests using another browser supply the name of that browser along with the `-b` switch. Available options are:
 
-Browser         | Example
-----------      | ---------------
-Chrome          | `-b chrome`
-Firefox         | `-b firefox`
-Electron        | `-b electron`        -- Electron support sketchy at the moment
-Chrome Headless | `-b chromeHeadless`  -- Only chrome headless support for now
-Custom          | `-b customDriver.js`
+Browser         | Example               | Further info
+----------      | ---------------       | ------------------
+Chrome          | `-b chrome`           |
+Firefox         | `-b firefox`          |
+Electron        | `-b electron`         | Electron support sketchy at the moment
+Chrome Headless | `-b chromeHeadless`   | Only chrome headless support for now
+Custom          | `-b customDriver.js`  |
 
 To use your own driver, create a customDriver.js file in the root of your project and provide the filename with the `-b` switch.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "chai": "3.5.0",
     "chalk": "1.1.3",
-    "chromedriver": "^94.0.0",
+    "chromedriver": "^95.0.0",
     "commander": "2.9.0",
     "cucumber": "1.3.3",
     "cucumber-html-reporter": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "chai": "3.5.0",
     "chalk": "1.1.3",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^96.0.0",
     "commander": "2.9.0",
     "cucumber": "1.3.3",
     "cucumber-html-reporter": "4.0.4",

--- a/runtime/chromeDriver.js
+++ b/runtime/chromeDriver.js
@@ -14,7 +14,8 @@ module.exports = function() {
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {
-            args: ['start-maximized', 'disable-extensions']
+            args: ['start-maximized', 'disable-extensions'],
+            excludeSwitches: ['enable-logging'] // Re-enable this if you want more verbose logging. Usually not needed.
         },
         path: chromedriver.path
     }).build();

--- a/runtime/chromeHeadless.js
+++ b/runtime/chromeHeadless.js
@@ -14,7 +14,8 @@ module.exports = function() {
         javascriptEnabled: true,
         acceptSslCerts: true,
         chromeOptions: {
-            args: ['disable-gpu', 'headless', 'disable-extensions', 'log-level=1'] // Remove or change log-level if you want more output.
+            args: ['disable-gpu', 'headless', 'disable-extensions', 'log-level=1'], // Remove or change log-level if you want more output.
+            excludeSwitches: ['enable-logging'] // Re-enable this if you want more verbose logging. Usually not needed.
         },
         path: chromedriver.path
     }).build();


### PR DESCRIPTION
Added switches to remove logging from chromedriver that seem to be unnecessary for day-to-day use, example: the famous bluetooth/usb not working logging in terminal while running tests on windows.